### PR TITLE
refactor: replace warp with axum and fix quick-xml deprecations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,30 +1296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1 0.10.6",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1862,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,16 +1906,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2131,26 +2167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3187,7 +3203,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3330,12 +3346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,6 +3435,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_stacker"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3445,17 +3466,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -3882,6 +3892,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3898,6 +3909,21 @@ dependencies = [
  "iri-string",
  "pin-project-lite",
  "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "http",
+ "percent-encoding",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]
@@ -3976,6 +4002,7 @@ dependencies = [
 name = "traffic-thrust"
 version = "0.2.2"
 dependencies = [
+ "axum",
  "chrono",
  "csv",
  "dotenvy",
@@ -3990,9 +4017,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
- "warp",
  "zip",
 ]
 
@@ -4013,12 +4040,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -4163,35 +4184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
-]
-
-[[package]]
-name = "warp"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a808122a8a77eecdabaefd88ddb1913c4be5ea1465399f63ba64c7aa705fea"
-dependencies = [
- "bytes",
- "futures-util",
- "headers",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-util",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4901,7 +4893,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "ppmd-rust",
- "sha1 0.11.0",
+ "sha1",
  "time",
  "typed-path",
  "zeroize",

--- a/crates/thrust/Cargo.toml
+++ b/crates/thrust/Cargo.toml
@@ -27,13 +27,14 @@ reqwest = { version = "0.12.28", default-features = false, features = ["blocking
 tokio = { version = "1", features = ["full"], optional = true }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", optional = true }
-warp = { version = "0.4.3", features = ["server"], optional = true }
+axum = { version = "0.8", features = ["macros", "tokio"], optional = true }
+tower-http = { version = "0.7", features = ["cors"], optional = true }
 zip = "8.6.0"
 
 [features]
 default = []
 net = ["dep:reqwest"]
-rest = ["dep:warp", "dep:tokio", "dep:tracing-subscriber"]
+rest = ["dep:axum", "dep:tokio", "dep:tracing-subscriber", "dep:tower-http"]
 
 [dev-dependencies]
 dotenvy = "0.15.7"

--- a/crates/thrust/examples/field15_serve.rs
+++ b/crates/thrust/examples/field15_serve.rs
@@ -1,9 +1,15 @@
+use axum::extract::{Json, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::Router;
 use serde::{Deserialize, Serialize};
 use std::env;
-use std::{path::Path, sync::Arc};
+use std::path::Path;
+use std::sync::Arc;
 use thrust::data::eurocontrol::database::AirwayDatabase;
 use thrust::data::field15::Field15Parser;
-use warp::Filter;
+use tower_http::cors::{Any, CorsLayer};
 
 #[derive(Debug, Deserialize)]
 struct RouteRequest {
@@ -20,24 +26,22 @@ struct AppState {
     database: AirwayDatabase,
 }
 
-fn with_state(
-    state: Arc<AppState>,
-) -> impl Filter<Extract = (Arc<AppState>,), Error = std::convert::Infallible> + Clone {
-    warp::any().map(move || state.clone())
-}
-
-async fn resolve_route(payload: RouteRequest, state: Arc<AppState>) -> Result<impl warp::Reply, warp::Rejection> {
+async fn resolve_route(
+    State(_state): State<Arc<AppState>>,
+    Json(payload): Json<RouteRequest>,
+) -> impl IntoResponse {
     eprintln!("Received route to resolve: {}", payload.route);
     let elements = Field15Parser::parse(&payload.route);
-    let enriched = state.database.enrich_route(elements);
+    let enriched = _state.database.enrich_route(elements);
 
-    Ok(warp::reply::with_status(
-        warp::reply::json(&RouteResponse {
+    (
+        StatusCode::OK,
+        Json(RouteResponse {
             route: payload.route.clone(),
             segments: enriched,
         }),
-        warp::http::StatusCode::OK,
-    ))
+    )
+        .into_response()
 }
 
 #[tokio::main]
@@ -61,23 +65,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let state = Arc::new(AppState { database });
 
     // Configure CORS
-    let cors = warp::cors()
-        .allow_any_origin()
-        .allow_methods(vec!["GET", "POST", "OPTIONS"])
-        .allow_headers(vec!["Content-Type", "Authorization"]);
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
 
     // Build the route
-    let resolve = warp::path("resolve")
-        .and(warp::post())
-        .and(warp::body::json())
-        .and(with_state(state))
-        .and_then(resolve_route)
-        .with(cors);
+    let app = Router::new()
+        .route("/resolve", post(resolve_route))
+        .with_state(state)
+        .layer(cors);
 
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
     println!("Server listening on http://127.0.0.1:3000");
     println!("POST to /resolve with JSON: {{\"route\": \"YOUR_ROUTE_STRING\"}}");
 
-    warp::serve(resolve).run(([127, 0, 0, 1], 3000)).await;
+    axum::serve(listener, app).await?;
 
     Ok(())
 }

--- a/crates/thrust/examples/field15_serve.rs
+++ b/crates/thrust/examples/field15_serve.rs
@@ -26,10 +26,7 @@ struct AppState {
     database: AirwayDatabase,
 }
 
-async fn resolve_route(
-    State(_state): State<Arc<AppState>>,
-    Json(payload): Json<RouteRequest>,
-) -> impl IntoResponse {
+async fn resolve_route(State(_state): State<Arc<AppState>>, Json(payload): Json<RouteRequest>) -> impl IntoResponse {
     eprintln!("Received route to resolve: {}", payload.route);
     let elements = Field15Parser::parse(&payload.route);
     let enriched = _state.database.enrich_route(elements);
@@ -65,10 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let state = Arc::new(AppState { database });
 
     // Configure CORS
-    let cors = CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods(Any)
-        .allow_headers(Any);
+    let cors = CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any);
 
     // Build the route
     let app = Router::new()

--- a/crates/thrust/src/data/eurocontrol/aixm/mod.rs
+++ b/crates/thrust/src/data/eurocontrol/aixm/mod.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use quick_xml::{events::Event, name::QName, Reader};
+use quick_xml::{events::Event, name::QName, Reader, XmlVersion};
 
 use crate::error::ThrustError;
 
@@ -46,7 +46,7 @@ fn find_node<'a, R: std::io::BufRead>(
                         for attr in e.attributes().with_checks(false) {
                             let attr = attr?;
                             let key = std::str::from_utf8(attr.key.0)?;
-                            attributes.insert(key.to_string(), attr.unescape_value()?.to_string());
+                            attributes.insert(key.to_string(), attr.normalized_value(XmlVersion::Implicit1_0)?.to_string());
                         }
 
                         return Ok(Node { name: *elt, attributes });
@@ -61,7 +61,7 @@ fn find_node<'a, R: std::io::BufRead>(
                         for attr in e.attributes().with_checks(false) {
                             let attr = attr?;
                             let key = std::str::from_utf8(attr.key.0)?;
-                            attributes.insert(key.to_string(), attr.unescape_value()?.to_string());
+                            attributes.insert(key.to_string(), attr.normalized_value(XmlVersion::Implicit1_0)?.to_string());
                         }
 
                         return Ok(Node { name: *elt, attributes });
@@ -116,7 +116,7 @@ pub fn read_attribute<R: std::io::BufRead>(
                 for attr in e.attributes().with_checks(false) {
                     let attr = attr?;
                     if attr.key == attr_name {
-                        return Ok(Some(attr.unescape_value()?.to_string()));
+                        return Ok(Some(attr.normalized_value(XmlVersion::Implicit1_0)?.to_string()));
                     }
                 }
             }

--- a/crates/thrust/src/data/eurocontrol/aixm/mod.rs
+++ b/crates/thrust/src/data/eurocontrol/aixm/mod.rs
@@ -46,7 +46,10 @@ fn find_node<'a, R: std::io::BufRead>(
                         for attr in e.attributes().with_checks(false) {
                             let attr = attr?;
                             let key = std::str::from_utf8(attr.key.0)?;
-                            attributes.insert(key.to_string(), attr.normalized_value(XmlVersion::Implicit1_0)?.to_string());
+                            attributes.insert(
+                                key.to_string(),
+                                attr.normalized_value(XmlVersion::Implicit1_0)?.to_string(),
+                            );
                         }
 
                         return Ok(Node { name: *elt, attributes });
@@ -61,7 +64,10 @@ fn find_node<'a, R: std::io::BufRead>(
                         for attr in e.attributes().with_checks(false) {
                             let attr = attr?;
                             let key = std::str::from_utf8(attr.key.0)?;
-                            attributes.insert(key.to_string(), attr.normalized_value(XmlVersion::Implicit1_0)?.to_string());
+                            attributes.insert(
+                                key.to_string(),
+                                attr.normalized_value(XmlVersion::Implicit1_0)?.to_string(),
+                            );
                         }
 
                         return Ok(Node { name: *elt, attributes });


### PR DESCRIPTION
warp 0.4 has known upstream regressions. This PR:

- Replaces warp 0.4 with axum 0.8 for the REST API (field15_serve example)
- Fixes quick-xml 0.41 deprecation warnings ( → )
- Adds tower-http for CORS layer

axum is the modern successor in the Tokio ecosystem with better type safety and active maintenance.